### PR TITLE
feat: migrations paths can be configured in the config file

### DIFF
--- a/commands/MongodbListMigrations.ts
+++ b/commands/MongodbListMigrations.ts
@@ -1,7 +1,7 @@
 import { inject } from '@adonisjs/fold';
 import CliTable from 'cli-table3';
 
-import { MongodbContract } from '@ioc:Mongodb/Database';
+import { Mongodb } from '../src/Mongodb';
 
 import MigrationCommand from './util/MigrationCommand';
 
@@ -13,7 +13,7 @@ export default class MongodbListMigrations extends MigrationCommand {
   };
 
   @inject(['Mongodb/Database'])
-  public async handle(db: MongodbContract): Promise<void> {
+  public async handle(db: Mongodb): Promise<void> {
     if (this.connection && !db.hasConnection(this.connection)) {
       this.logger.error(
         `No MongoDB connection registered with name "${this.connection}"`,

--- a/commands/MongodbListMigrations.ts
+++ b/commands/MongodbListMigrations.ts
@@ -25,7 +25,7 @@ export default class MongodbListMigrations extends MigrationCommand {
       const database = await db.connection().database();
       const coll = database.collection('__adonis_mongodb');
       const migrationNames = await this.getMigrationFiles(
-        db.connection().$config,
+        db.connection().config,
       );
 
       const migrationDocuments = await coll.find({}).toArray();

--- a/commands/MongodbListMigrations.ts
+++ b/commands/MongodbListMigrations.ts
@@ -24,7 +24,9 @@ export default class MongodbListMigrations extends MigrationCommand {
     try {
       const database = await db.connection().database();
       const coll = database.collection('__adonis_mongodb');
-      const migrationNames = await this.getMigrationFiles();
+      const migrationNames = await this.getMigrationFiles(
+        db.connection().$config,
+      );
 
       const migrationDocuments = await coll.find({}).toArray();
 

--- a/commands/MongodbMigrate.ts
+++ b/commands/MongodbMigrate.ts
@@ -7,7 +7,6 @@ import MigrationCommand, {
   migrationLockCollectionName,
 } from './util/MigrationCommand';
 
-
 export default class MongodbMigrate extends MigrationCommand {
   public static commandName = 'mongodb:migration:run';
   public static description = 'Execute pending migrations';

--- a/commands/MongodbMigrate.ts
+++ b/commands/MongodbMigrate.ts
@@ -1,11 +1,12 @@
 import { inject } from '@adonisjs/fold';
 
-import { MongodbContract } from '@ioc:Mongodb/Database';
+import { Mongodb } from '../src/Mongodb';
 
 import MigrationCommand, {
   migrationCollectionName,
   migrationLockCollectionName,
 } from './util/MigrationCommand';
+
 
 export default class MongodbMigrate extends MigrationCommand {
   public static commandName = 'mongodb:migration:run';
@@ -14,7 +15,7 @@ export default class MongodbMigrate extends MigrationCommand {
     loadApp: true,
   };
 
-  private async _executeMigration(db: MongodbContract): Promise<void> {
+  private async _executeMigration(db: Mongodb): Promise<void> {
     let migrationFiles = await this.getMigrationFiles(db.connection().config);
     const connectionName = this.connection || undefined;
     const connection = db.connection(connectionName);
@@ -126,7 +127,7 @@ export default class MongodbMigrate extends MigrationCommand {
   }
 
   @inject(['Mongodb/Database'])
-  public async handle(db: MongodbContract): Promise<void> {
+  public async handle(db: Mongodb): Promise<void> {
     if (this.connection && !db.hasConnection(this.connection)) {
       this.logger.error(
         `No MongoDB connection registered with name "${this.connection}"`,

--- a/commands/MongodbMigrate.ts
+++ b/commands/MongodbMigrate.ts
@@ -15,7 +15,7 @@ export default class MongodbMigrate extends MigrationCommand {
   };
 
   private async _executeMigration(db: MongodbContract): Promise<void> {
-    let migrationFiles = await this.getMigrationFiles();
+    let migrationFiles = await this.getMigrationFiles(db.connection().$config);
     const connectionName = this.connection || undefined;
     const connection = db.connection(connectionName);
 

--- a/commands/MongodbMigrate.ts
+++ b/commands/MongodbMigrate.ts
@@ -15,7 +15,7 @@ export default class MongodbMigrate extends MigrationCommand {
   };
 
   private async _executeMigration(db: MongodbContract): Promise<void> {
-    let migrationFiles = await this.getMigrationFiles(db.connection().$config);
+    let migrationFiles = await this.getMigrationFiles(db.connection().config);
     const connectionName = this.connection || undefined;
     const connection = db.connection(connectionName);
 

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -64,7 +64,6 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
     let migrationNames = migrationFiles.sort((a, b) =>
       basename(a, '.js').localeCompare(basename(b, '.js')),
     );
-    console.log(migrationNames);
     // Check migration file names
     let hadBadName = false;
     migrationNames

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -39,7 +39,7 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
   ): Promise<string[]> {
     const folders =
       config.migrations && config.migrations.length > 0
-        ? [folder, ...config.migrations]
+        ? config.migrations
         : [folder];
 
     const migrationFiles: string[] = (

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { join, basename } from 'path';
+import { join, basename, extname } from 'path';
 
 import { BaseCommand, flags } from '@adonisjs/ace';
 import { Logger } from '@poppinss/fancy-logs';
@@ -49,7 +49,9 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
           .map(async (migrationsPath) => {
             try {
               const files = await fs.readdir(migrationsPath);
-              return files.map((file) => join(migrationsPath, file));
+              return files
+                .filter((file) => extname(file) === '.js')
+                .map((file) => join(migrationsPath, file));
             } catch {
               return null;
             }
@@ -62,7 +64,7 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
     let migrationNames = migrationFiles.sort((a, b) =>
       basename(a, '.js').localeCompare(basename(b, '.js')),
     );
-
+    console.log(migrationNames);
     // Check migration file names
     let hadBadName = false;
     migrationNames

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -5,8 +5,8 @@ import { BaseCommand, flags } from '@adonisjs/ace';
 import { Logger } from '@poppinss/fancy-logs';
 import { ClientSession } from 'mongodb';
 
+import { MongodbConnectionConfig } from '@ioc:Mongodb/Database';
 import BaseMigration from '@ioc:Mongodb/Migration';
-import { MongodbConfig, MongodbConnectionConfig } from '@ioc:Mongodb/Database';
 
 const matchTimestamp = /^(?<timestamp>\d+)_.*$/;
 const folder = 'mongodb/migrations';

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -87,8 +87,7 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
   protected async importMigration(
     name: string,
   ): Promise<{ Migration: MigrationModule['default']; description?: string }> {
-    const filePath = name;
-    const module: MigrationModule = await import(filePath);
+    const module: MigrationModule = await import(name);
     const { default: Migration, description } = module;
     if (!Migration || typeof Migration !== 'function') {
       throw new Error(`Migration in ${name} must export a default class`);

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -1,11 +1,12 @@
 import fs from 'fs/promises';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 import { BaseCommand, flags } from '@adonisjs/ace';
 import { Logger } from '@poppinss/fancy-logs';
 import { ClientSession } from 'mongodb';
 
 import BaseMigration from '@ioc:Mongodb/Migration';
+import { MongodbConfig, MongodbConnectionConfig } from '@ioc:Mongodb/Database';
 
 const matchTimestamp = /^(?<timestamp>\d+)_.*$/;
 const folder = 'mongodb/migrations';
@@ -33,28 +34,49 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
   @flags.string({ description: 'Database connection to use for the migration' })
   public connection: string;
 
-  protected getMigrationFilePath(file: string) {
-    return join(this.application.appRoot, folder, file);
-  }
+  protected async getMigrationFiles(
+    config: MongodbConnectionConfig,
+  ): Promise<string[]> {
+    const folders =
+      config.migrations && config.migrations.length > 0
+        ? [folder, ...config.migrations]
+        : [folder];
 
-  protected async getMigrationFiles(): Promise<string[]> {
-    const migrationsPath = join(this.application.appRoot, folder);
-    let migrationNames = (await fs.readdir(migrationsPath)).sort((a, b) =>
-      a.localeCompare(b),
+    const migrationFiles: string[] = (
+      await Promise.all(
+        folders
+          .map((folder) => join(this.application.appRoot, folder))
+          .map(async (migrationsPath) => {
+            try {
+              const files = await fs.readdir(migrationsPath);
+              return files.map((file) => join(migrationsPath, file));
+            } catch {
+              return null;
+            }
+          }),
+      )
+    )
+      .filter((migrationFile) => migrationFile !== null)
+      .flat() as string[];
+
+    let migrationNames = migrationFiles.sort((a, b) =>
+      basename(a, '.js').localeCompare(basename(b, '.js')),
     );
 
     // Check migration file names
     let hadBadName = false;
-    migrationNames.forEach((migrationName) => {
-      const match = matchTimestamp.exec(migrationName);
-      const timestamp = Number(match?.groups?.timestamp);
-      if (Number.isNaN(timestamp) || timestamp === 0) {
-        hadBadName = true;
-        this.logger.error(
-          `Invalid migration file: ${migrationName}. Name must start with a timestamp`,
-        );
-      }
-    });
+    migrationNames
+      .map((migrationName) => basename(migrationName, '.js'))
+      .forEach((migrationName) => {
+        const match = matchTimestamp.exec(migrationName);
+        const timestamp = Number(match?.groups?.timestamp);
+        if (Number.isNaN(timestamp) || timestamp === 0) {
+          hadBadName = true;
+          this.logger.error(
+            `Invalid migration file: ${migrationName}. Name must start with a timestamp`,
+          );
+        }
+      });
 
     if (hadBadName) {
       throw new Error('some migration files are malformed');
@@ -65,7 +87,7 @@ export default abstract class MongodbMakeMigration extends BaseCommand {
   protected async importMigration(
     name: string,
   ): Promise<{ Migration: MigrationModule['default']; description?: string }> {
-    const filePath = this.getMigrationFilePath(name);
+    const filePath = name;
     const module: MigrationModule = await import(filePath);
     const { default: Migration, description } = module;
     if (!Migration || typeof Migration !== 'function') {

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -14,11 +14,12 @@ enum ConnectionStatus {
 
 export class Connection implements ConnectionContract {
   private $name: string;
-  public $config: MongodbConnectionConfig;
   private $logger: LoggerContract;
   private $status: ConnectionStatus;
   private $client: MongoClient;
   private $connectPromise: Promise<Db> | null;
+
+  public config: MongodbConnectionConfig;
 
   public constructor(
     name: string,
@@ -26,13 +27,13 @@ export class Connection implements ConnectionContract {
     logger: LoggerContract,
   ) {
     this.$name = name;
-    this.$config = config;
+    this.config = config;
     this.$logger = logger;
     this.$status = ConnectionStatus.DISCONNECTED;
-    this.$client = new MongoClient(this.$config.url, {
+    this.$client = new MongoClient(this.config.url, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-      ...this.$config.clientOptions,
+      ...this.config.clientOptions,
     });
     this.$connectPromise = null;
   }
@@ -56,7 +57,7 @@ export class Connection implements ConnectionContract {
     this.$status = ConnectionStatus.CONNECTED;
     this.$connectPromise = this.$client
       .connect()
-      .then((client) => client.db(this.$config.database));
+      .then((client) => client.db(this.config.database));
     this.$connectPromise.catch((error) => {
       this.$logger.fatal(
         `could not connect to database "${this.$name}"`,

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -14,7 +14,7 @@ enum ConnectionStatus {
 
 export class Connection implements ConnectionContract {
   private $name: string;
-  private $config: MongodbConnectionConfig;
+  public $config: MongodbConnectionConfig;
   private $logger: LoggerContract;
   private $status: ConnectionStatus;
   private $client: MongoClient;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ declare module '@ioc:Mongodb/Database' {
     transaction<TResult>(
       handler: (session: ClientSession, db: Db) => Promise<TResult>,
     ): Promise<TResult>;
-    config: MongodbConnectionConfig;
   }
 
   const mongodb: MongodbContract;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ declare module '@ioc:Mongodb/Database' {
     transaction<TResult>(
       handler: (session: ClientSession, db: Db) => Promise<TResult>,
     ): Promise<TResult>;
-    $config: MongodbConnectionConfig;
+    config: MongodbConnectionConfig;
   }
 
   const mongodb: MongodbContract;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ declare module '@ioc:Mongodb/Database' {
     url: string;
     database: string;
     clientOptions?: MongoClientOptions;
+    migrations?: string[];
   }
 
   export interface MongodbContract {
@@ -32,6 +33,7 @@ declare module '@ioc:Mongodb/Database' {
     transaction<TResult>(
       handler: (session: ClientSession, db: Db) => Promise<TResult>,
     ): Promise<TResult>;
+    $config: MongodbConnectionConfig;
   }
 
   const mongodb: MongodbContract;


### PR DESCRIPTION
The PR adds a new optional `migrations` connection config key. 
The value should be an array of path where the migrations can be found.

The default behavior is kept (if no `migrations` key in the config: lookup in `mongodb/migrations`).
If a `migrations` key is specified, it lookups the migrations available in the listed folder AND in the `mongodb/migrations` folder. That's a choice that can be discussed of course. 