### PR TITLE
Refactor ODM - part 3

### DIFF
--- a/adonis-typings/database.ts
+++ b/adonis-typings/database.ts
@@ -156,7 +156,7 @@ declare module '@ioc:Zakodium/Mongodb/Database' {
       collectionName: string,
     ): Promise<Collection<TSchema>>;
     transaction<TResult>(
-      handler: (session: ClientSession, db: Db) => Promise<TResult>,
+      handler: (client: ClientSession, db: Db) => Promise<TResult>,
     ): Promise<TResult>;
   }
 

--- a/adonis-typings/migration.ts
+++ b/adonis-typings/migration.ts
@@ -15,7 +15,7 @@ declare module '@ioc:Zakodium/Mongodb/Migration' {
       options?: CreateIndexesOptions,
     ): void;
     public defer(
-      callback: (db: Db, session: ClientSession) => Promise<void>,
+      callback: (db: Db, client: ClientSession) => Promise<void>,
     ): void;
     public abstract up(): void;
     public execUp(): Promise<void>;

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -3,11 +3,11 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     Collection,
     Filter,
     FindOptions,
-    UpdateOptions,
     InsertOneOptions,
     DeleteOptions,
     CountDocumentsOptions,
     BulkWriteOptions,
+    ClientSession,
   } from 'mongodb';
 
   import { UserProviderContract } from '@ioc:Adonis/Addons/Auth';
@@ -30,6 +30,18 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
   type ModelAttributes<T> = Omit<T, ModelReadonlyFields>;
 
   /**
+   * Model adapter options
+   */
+  export interface ModelAdapterOptions<
+    DriverOptionType extends { session?: ClientSession },
+  > {
+    client?: ClientSession;
+    // TODO: add connection option.
+    // https://docs.adonisjs.com/reference/orm/base-model#model-adapter-options
+    driverOptions?: Omit<DriverOptionType, 'session'>;
+  }
+
+  /**
    * Shape of the model static properties.
    *
    */
@@ -50,7 +62,7 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     count<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       filter: Filter<ModelAttributes<InstanceType<ModelType>>>,
-      options?: CountDocumentsOptions,
+      options?: ModelAdapterOptions<CountDocumentsOptions>,
     ): Promise<number>;
 
     /**
@@ -59,7 +71,7 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     create<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       value: Partial<ModelAttributes<InstanceType<ModelType>>>,
-      options?: InsertOneOptions,
+      options?: ModelAdapterOptions<InsertOneOptions>,
     ): Promise<InstanceType<ModelType>>;
 
     /**
@@ -68,7 +80,7 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     createMany<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       values: Array<Partial<ModelAttributes<InstanceType<ModelType>>>>,
-      options?: BulkWriteOptions,
+      options?: ModelAdapterOptions<BulkWriteOptions>,
     ): Promise<Array<InstanceType<ModelType>>>;
 
     /**
@@ -77,7 +89,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     find<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       id: InstanceType<ModelType>['_id'],
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<InstanceType<ModelType> | null>;
 
     /**
@@ -86,7 +100,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     findOrFail<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       id: InstanceType<ModelType>['_id'],
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<InstanceType<ModelType>>;
 
     /**
@@ -96,7 +112,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
       this: ModelType,
       key: string,
       value: unknown,
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<InstanceType<ModelType> | null>;
 
     /**
@@ -106,7 +124,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
       this: ModelType,
       key: string,
       value: unknown,
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<InstanceType<ModelType>>;
 
     /**
@@ -115,7 +135,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     findMany<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       ids: Array<InstanceType<ModelType>['_id']>,
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<Array<InstanceType<ModelType>>>;
 
     /**
@@ -123,7 +145,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      */
     all<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): Promise<Array<InstanceType<ModelType>>>;
 
     /**
@@ -132,7 +156,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     query<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
       filter: Filter<ModelAttributes<InstanceType<ModelType>>>,
-      options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
+      options?: ModelAdapterOptions<
+        FindOptions<ModelAttributes<InstanceType<ModelType>>>
+      >,
     ): QueryContract<InstanceType<ModelType>>;
 
     /**
@@ -144,6 +170,10 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     ): Promise<Collection<ModelAttributes<InstanceType<ModelType>>>>;
 
     new (): MongodbDocument<IdType>;
+  }
+
+  export interface ModelDocumentOptions<DriverOptionType> {
+    driverOptions?: Omit<DriverOptionType, 'session'>;
   }
 
   export interface MongodbDocument<IdType> {
@@ -167,13 +197,13 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      * Save the entry to the database.
      * @returns - whether the entry was changed.
      */
-    save(options?: UpdateOptions): Promise<boolean>;
+    save(options?: ModelDocumentOptions<InsertOneOptions>): Promise<boolean>;
 
     /**
      * Delete the entry from the database.
      * @returns - whether the entry was deleted.
      */
-    delete(options?: DeleteOptions): Promise<boolean>;
+    delete(options?: ModelDocumentOptions<DeleteOptions>): Promise<boolean>;
 
     /**
      * Merge given values into the model instance.

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -203,6 +203,8 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     first(): Promise<DocumentType | null>;
     firstOrFail(): Promise<DocumentType>;
     all(): Promise<DocumentType[]>;
+    count(): Promise<number>;
+    distinct<T = unknown>(key: string): Promise<T[]>;
     [Symbol.asyncIterator](): AsyncIterableIterator<DocumentType>;
   }
 

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -140,6 +140,7 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      */
     getCollection<ModelType extends MongodbModel<IdType>>(
       this: ModelType,
+      connection?: string,
     ): Promise<Collection<ModelAttributes<InstanceType<ModelType>>>>;
 
     new (): MongodbDocument<IdType>;

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -13,21 +13,21 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
   import { UserProviderContract } from '@ioc:Adonis/Addons/Auth';
   import { HashersList } from '@ioc:Adonis/Core/Hash';
 
-  type ModelReadonlyFields =
+  type DollarProperties<T> = Extract<keyof T, `$${string}`>;
+
+  type ModelMethods =
     | 'id'
     | 'isDirty'
     | 'toJSON'
     | 'save'
     | 'delete'
     | 'merge'
-    | 'fill'
-    | 'createdAt'
-    | 'updatedAt';
+    | 'fill';
 
   /**
    * TODO: implement this correctly
    */
-  type ModelAttributes<T> = Omit<T, ModelReadonlyFields>;
+  type ModelAttributes<T> = Omit<T, ModelMethods | DollarProperties<T>>;
 
   /**
    * Model adapter options
@@ -183,6 +183,8 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     readonly createdAt: Date;
     readonly updatedAt: Date;
 
+    readonly $isDeleted: boolean;
+
     /**
      * Returns the Model's current data
      */
@@ -210,9 +212,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      * @param values - Values to merge with.
      * @returns - modified model instance.
      */
-    merge<T extends Partial<Omit<this, '_id' | 'id' | ModelReadonlyFields>>>(
+    merge<T extends Partial<Omit<this, '_id' | 'id' | ModelMethods>>>(
       values: NoExtraProperties<
-        Partial<Omit<this, '_id' | 'id' | ModelReadonlyFields>>,
+        Partial<Omit<this, '_id' | 'id' | ModelMethods>>,
         T
       >,
     ): this;
@@ -222,9 +224,9 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      * @param values - Values to fill in.
      * @returns - modified model instance.
      */
-    fill<T extends Partial<Omit<this, '_id' | 'id' | ModelReadonlyFields>>>(
+    fill<T extends Partial<Omit<this, '_id' | 'id' | ModelMethods>>>(
       values: NoExtraProperties<
-        Partial<Omit<this, '_id' | 'id' | ModelReadonlyFields>>,
+        Partial<Omit<this, '_id' | 'id' | ModelMethods>>,
         T
       >,
     ): this;

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -340,12 +340,13 @@ export class BaseModel {
 
   public static async getCollection<ModelType extends typeof BaseModel>(
     this: ModelType,
+    connection = this.connection,
   ): Promise<Collection<ModelAttributes<InstanceType<ModelType>>>> {
     if (!this.$database) {
       throw new Error('Model should only be accessed from IoC container');
     }
-    const connection = this.$database.connection(this.connection);
-    return connection.collection(this.$getCollectionName());
+    const connectionInstance = this.$database.connection(connection);
+    return connectionInstance.collection(this.$getCollectionName());
   }
 
   public [Symbol.for('nodejs.util.inspect.custom')](): any {

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -5,7 +5,9 @@ import {
   ClientSession,
   Collection,
   CountDocumentsOptions,
+  CountOptions,
   DeleteOptions,
+  DistinctOptions,
   Filter,
   FindOptions,
   InsertOneOptions,
@@ -75,6 +77,20 @@ class Query<ModelType extends typeof BaseModel>
           },
           true,
         ) as InstanceType<ModelType>,
+    );
+  }
+
+  public async count(): Promise<number> {
+    const collection = await this.modelConstructor.getCollection();
+    return collection.countDocuments(this.filter, this.options as CountOptions);
+  }
+
+  public async distinct<T = unknown>(key: string): Promise<T[]> {
+    const collection = await this.modelConstructor.getCollection();
+    return collection.distinct(
+      key,
+      this.filter,
+      this.options as DistinctOptions,
     );
   }
 
@@ -316,7 +332,7 @@ export class BaseModel {
 
   public static query<ModelType extends typeof BaseModel>(
     this: ModelType,
-    filter: Filter<ModelAttributes<InstanceType<ModelType>>>,
+    filter: Filter<ModelAttributes<InstanceType<ModelType>>> = {},
     options?: FindOptions<ModelAttributes<InstanceType<ModelType>>>,
   ): Query<ModelType> {
     return new Query(filter, options, this);

--- a/src/Model/__tests__/Model.query.test.ts
+++ b/src/Model/__tests__/Model.query.test.ts
@@ -21,32 +21,62 @@ beforeAll(async () => {
 });
 
 test('query.all', async () => {
-  const results = await TestModel.query({}).all();
+  const results = await TestModel.query().all();
   expect(results).toHaveLength(5);
   expect(results[0].testField).toContain('test');
   expect(results[0]).toBeInstanceOf(TestModel);
 });
 
 test('query.first', async () => {
-  const result = await TestModel.query({}).first();
+  const result = await TestModel.query().first();
   expect(result).toBeInstanceOf(TestModel);
   expect((result as TestModel).testField).toBe('test1');
 });
 
 test('query.firstOrFail', async () => {
-  const result = await TestModel.query({}).firstOrFail();
+  const result = await TestModel.query().firstOrFail();
   expect(result).toBeInstanceOf(TestModel);
   expect(result.testField).toBe('test1');
 });
 
+test('query.firstOrFail - uses the filter', async () => {
+  const result = await TestModel.query({ testField: 'test2' }).firstOrFail();
+  expect(result).toBeInstanceOf(TestModel);
+  expect(result.testField).toBe('test2');
+});
+
 test('query.firstOrFail - fail if collection is empty', async () => {
-  await expect(EmptyTestModel.query({}).firstOrFail()).rejects.toThrow(
+  await expect(EmptyTestModel.query().firstOrFail()).rejects.toThrow(
     /E_DOCUMENT_NOT_FOUND/,
   );
 });
 
+test('query.firstOrFail - fail if filter matches nothing', async () => {
+  await expect(
+    TestModel.query({ testField: 'bad' }).firstOrFail(),
+  ).rejects.toThrow(/E_DOCUMENT_NOT_FOUND/);
+});
+
+test('query.count - all', async () => {
+  const count = await TestModel.query().count();
+  expect(count).toBe(5);
+});
+
+test('query.count - with filter', async () => {
+  const count = await TestModel.query({
+    testField: { $regex: /test[123]/ },
+  }).count();
+  expect(count).toBe(3);
+});
+
+test('query.distinct', async () => {
+  const results = await TestModel.query().distinct('testField');
+  expect(results).toHaveLength(5);
+  expect(results[0]).toBe('test1');
+});
+
 test('query async iterator', async () => {
-  const results = TestModel.query({});
+  const results = TestModel.query();
   let count = 0;
   for await (const result of results) {
     count++;

--- a/src/Model/__tests__/Model.query.test.ts
+++ b/src/Model/__tests__/Model.query.test.ts
@@ -23,20 +23,20 @@ beforeAll(async () => {
 test('query.all', async () => {
   const results = await TestModel.query().all();
   expect(results).toHaveLength(5);
-  expect(results[0].testField).toContain('test');
+  expect(results[0].testField).toBe('test5');
   expect(results[0]).toBeInstanceOf(TestModel);
 });
 
 test('query.first', async () => {
   const result = await TestModel.query().first();
   expect(result).toBeInstanceOf(TestModel);
-  expect((result as TestModel).testField).toBe('test1');
+  expect((result as TestModel).testField).toBe('test5');
 });
 
 test('query.firstOrFail', async () => {
   const result = await TestModel.query().firstOrFail();
   expect(result).toBeInstanceOf(TestModel);
-  expect(result.testField).toBe('test1');
+  expect(result.testField).toBe('test5');
 });
 
 test('query.firstOrFail - uses the filter', async () => {
@@ -79,12 +79,13 @@ test('query async iterator', async () => {
   const results = TestModel.query();
   let count = 0;
   for await (const result of results) {
-    count++;
     expect(result).toBeInstanceOf(TestModel);
-    expect(result.testField).toContain('test');
+    // It should be sorted by default
+    expect(result.testField).toBe(`test${5 - count}`);
     result.otherField = true;
     await result.save();
     expect(result.otherField).toBe(true);
+    count++;
   }
   expect(count).toBe(5);
 });

--- a/src/Model/__tests__/Model.test.ts
+++ b/src/Model/__tests__/Model.test.ts
@@ -116,7 +116,12 @@ test('delete on model', async () => {
     password: 'root',
   });
 
+  expect(user.$isDeleted).toBe(false);
   await user.delete();
+  expect(user.$isDeleted).toBe(true);
+
+  await expect(user.save()).rejects.toThrow(/E_DOCUMENT_DELETED/);
+  await expect(user.delete()).rejects.toThrow(/E_DOCUMENT_DELETED/);
 
   const sameUserButDeleted = await User.find(user._id);
   expect(sameUserButDeleted).toBeNull();

--- a/src/Model/__tests__/Model.test.ts
+++ b/src/Model/__tests__/Model.test.ts
@@ -137,15 +137,15 @@ test('AutoIncrementModel id increments', async () => {
   expect(firstPost.id).toBe(secondPost._id - 1);
 });
 
-test('passing session should run requests within the same session', async () => {
+test('passing client should run requests within the same transaction session', async () => {
   const username = nextUsername();
-  await db.connection('mongo').transaction(async (session) => {
+  await db.connection('mongo').transaction(async (client) => {
     const user = await User.create(
       {
         username: username,
         password: 'rootroot',
       },
-      { session },
+      { client },
     );
 
     user.password = 'root';

--- a/src/Model/__tests__/Model.test.ts
+++ b/src/Model/__tests__/Model.test.ts
@@ -81,6 +81,12 @@ test("find by id should throw when doesn't exists", async () => {
   await expect(t).rejects.toThrow(/E_DOCUMENT_NOT_FOUND/);
 });
 
+test('find all', async () => {
+  const users = await User.all();
+  expect(users).toHaveLength(2);
+  expect(users[0].username).toBe('root2');
+});
+
 test('saved changes should be sent to database', async () => {
   const user = await User.create({
     username: nextUsername(),


### PR DESCRIPTION
- feat: make query filter optional, add query.count and query.distinct
- feat: allow to change the connection used in Model.getCollection
- refactor!: move mongodb driver options to options.driverOptions
