### PR TITLE
Add `afterUpSuccess` method to migrations

### DIFF
--- a/adonis-typings/migration.ts
+++ b/adonis-typings/migration.ts
@@ -24,6 +24,6 @@ declare module '@ioc:Zakodium/Mongodb/Migration' {
       callback: (db: Db, client: ClientSession) => Promise<void>,
     ): void;
     public abstract up(): void;
-    public execUp(): Promise<void>;
+    public execUp(session: ClientSession): Promise<void>;
   }
 }

--- a/adonis-typings/migration.ts
+++ b/adonis-typings/migration.ts
@@ -24,6 +24,7 @@ declare module '@ioc:Zakodium/Mongodb/Migration' {
       callback: (db: Db, client: ClientSession) => Promise<void>,
     ): void;
     public abstract up(): void;
+    public afterUpSuccess?(): unknown;
     public execUp(session: ClientSession): Promise<void>;
   }
 }

--- a/commands/MongodbMigrate.ts
+++ b/commands/MongodbMigrate.ts
@@ -2,12 +2,12 @@ import { inject } from '@adonisjs/core/build/standalone';
 import { ObjectId } from 'mongodb';
 
 import { DatabaseContract } from '@ioc:Zakodium/Mongodb/Database';
+import Migration from '@ioc:Zakodium/Mongodb/Migration';
 
 import MigrationCommand, {
   migrationCollectionName,
   migrationLockCollectionName,
 } from './util/MigrationCommand';
-import Migration from '@ioc:Zakodium/Mongodb/Migration';
 
 interface IMigration {
   _id: ObjectId | undefined;
@@ -121,6 +121,17 @@ export default class MongodbMigrate extends MigrationCommand {
 
       if (lastMigrationError) {
         break;
+      }
+
+      if (migration.afterUpSuccess) {
+        try {
+          await migration.afterUpSuccess();
+        } catch (error) {
+          this.logger.warning(`Migration's afterUpSuccess call failed`);
+          // TODO: See if there can be a way in Ace commands to print error stack traces
+          // eslint-disable-next-line no-console
+          console.warn(error);
+        }
       }
 
       successfullyExecuted++;

--- a/commands/util/MigrationCommand.ts
+++ b/commands/util/MigrationCommand.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 import { BaseCommand, flags } from '@adonisjs/core/build/standalone';
 import { Logger } from '@poppinss/cliui/build/src/Logger';
-import { ClientSession } from 'mongodb';
 
 import type {
   ConnectionContract,
@@ -25,7 +24,6 @@ interface MigrationModule {
   default: new (
     connection: string | undefined,
     logger: Logger,
-    session: ClientSession,
   ) => BaseMigration;
   description?: string;
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@poppinss/utils": "^5.0.0",
     "cli-table3": "^0.6.3",
     "lodash": "^4.17.21",
-    "mongodb": "^5.4.0",
+    "mongodb": "^5.5.0",
     "pluralize": "^8.0.0"
   }
 }

--- a/src/Migration.ts
+++ b/src/Migration.ts
@@ -173,6 +173,7 @@ export default function createMigration(Database: DatabaseContract): any {
     }
 
     public abstract up(): void;
+    public afterUpSuccess?(): void;
   }
 
   return Migration;

--- a/src/__tests__/Migration.test.ts
+++ b/src/__tests__/Migration.test.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@poppinss/cliui/build/src/Logger';
-import { ClientSession } from 'mongodb';
 
 import { getMongodb } from '../../test-utils/TestUtils';
 import createMigration from '../Migration';
@@ -9,12 +8,8 @@ const db = getMongodb();
 const BaseMigration = createMigration(db);
 
 class TestMigration extends BaseMigration {
-  public constructor(
-    connection: string | undefined,
-    logger: Logger,
-    session: ClientSession,
-  ) {
-    super(connection, logger, session);
+  public constructor(connection: string | undefined, logger: Logger) {
+    super(connection, logger);
   }
   public up(): void {
     this.createCollection('migration');
@@ -29,8 +24,8 @@ afterAll(async () => {
 
 test('runs a migration correctly edit database', async () => {
   await db.connection('mongo').transaction(async (session) => {
-    const migration = new TestMigration('mongo', logger, session);
-    await migration.execUp();
+    const migration = new TestMigration('mongo', logger);
+    await migration.execUp(session);
   });
   const database = await db.connection('mongo').database();
   const collections = await database.listCollections().toArray();


### PR DESCRIPTION
- refactor: import migration class before starting the transaction
- feat: add `afterUpSuccess` method to migrations
