### PR TITLE
feat: add `useTransaction` to BaseModel

### DIFF
--- a/adonis-typings/database.ts
+++ b/adonis-typings/database.ts
@@ -2,6 +2,7 @@ declare module '@ioc:Zakodium/Mongodb/Database' {
   import { EventEmitter } from 'node:events';
 
   import {
+    TransactionOptions,
     MongoClientOptions,
     Collection,
     Db,
@@ -46,6 +47,17 @@ declare module '@ioc:Zakodium/Mongodb/Database' {
      * Connection manager.
      */
     manager: ConnectionManagerContract;
+
+    /**
+     * Shortcut to `Database.connection().transaction()`
+     *
+     * @param handler
+     * @param options
+     */
+    transaction<TResult>(
+      handler: (client: ClientSession, db: Db) => Promise<TResult>,
+      options?: TransactionOptions,
+    ): Promise<TResult>;
   }
 
   /**
@@ -158,6 +170,7 @@ declare module '@ioc:Zakodium/Mongodb/Database' {
     ): Promise<Collection<TSchema>>;
     transaction<TResult>(
       handler: (client: ClientSession, db: Db) => Promise<TResult>,
+      options?: TransactionOptions,
     ): Promise<TResult>;
   }
 

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -255,6 +255,36 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
     readonly $isDirty: boolean;
 
     /**
+     * Return the client session of the transaction
+     */
+    readonly $trx: ClientSession | undefined;
+
+    /**
+     * Assign client to model options for transactions use.
+     * Will throw an error if model instance already linked to a session
+     *
+     * It allows to use model init outside a transaction, but save it within a transaction.
+     *
+     * @param client
+     *
+     * @example
+     * ```ts
+     * const label = await Label.findOrFail(1);
+     * // edit some label props
+     *
+     * Database.transaction((client) => {
+     *  const documents = await Document.query({ labels: label._id }, { client }).all()
+     *  // remove label from documents when new label definition is incompatible
+     *  // call .save() for each changed documents (aware of transaction because is from query with client option)
+     *
+     *  label.useTransaction(client);
+     *  label.save();
+     * })
+     * ```
+     */
+    useTransaction(client: ClientSession): this;
+
+    /**
      * Returns the Model's current data
      */
     toJSON(): unknown;

--- a/adonis-typings/odm.ts
+++ b/adonis-typings/odm.ts
@@ -258,6 +258,7 @@ declare module '@ioc:Zakodium/Mongodb/Odm' {
      * Return the client session of the transaction
      */
     readonly $trx: ClientSession | undefined;
+    readonly $isTransaction: boolean;
 
     /**
      * Assign client to model options for transactions use.

--- a/src/Database/Connection.ts
+++ b/src/Database/Connection.ts
@@ -135,13 +135,10 @@ export class Connection extends EventEmitter implements ConnectionContract {
     options?: TransactionOptions,
   ): Promise<TResult> {
     const db = await this._ensureDb();
-    let result: TResult;
-    await this.client.withSession(async (session) => {
+    return this.client.withSession(async (session) => {
       return session.withTransaction(async (session) => {
-        result = await handler(session, db);
+        return handler(session, db);
       }, options);
     });
-    // @ts-expect-error The `await` ensures `result` has a value.
-    return result;
   }
 }

--- a/src/Database/Connection.ts
+++ b/src/Database/Connection.ts
@@ -135,10 +135,13 @@ export class Connection extends EventEmitter implements ConnectionContract {
     options?: TransactionOptions,
   ): Promise<TResult> {
     const db = await this._ensureDb();
-    return this.client.withSession(async (session) => {
+    let result: TResult;
+    await this.client.withSession(async (session) => {
       return session.withTransaction(async (session) => {
-        return handler(session, db);
+        result = await handler(session, db);
       }, options);
     });
+    // @ts-expect-error The `await` ensures `result` has a value.
+    return result;
   }
 }

--- a/src/Database/Connection.ts
+++ b/src/Database/Connection.ts
@@ -1,7 +1,14 @@
 import { EventEmitter } from 'node:events';
 
 import { Exception } from '@poppinss/utils';
-import { MongoClient, Db, Collection, ClientSession, Document } from 'mongodb';
+import {
+  MongoClient,
+  Db,
+  Collection,
+  ClientSession,
+  Document,
+  TransactionOptions,
+} from 'mongodb';
 
 import { LoggerContract } from '@ioc:Adonis/Core/Logger';
 import type {
@@ -125,13 +132,14 @@ export class Connection extends EventEmitter implements ConnectionContract {
 
   public async transaction<TResult>(
     handler: (session: ClientSession, db: Db) => Promise<TResult>,
+    options?: TransactionOptions,
   ): Promise<TResult> {
     const db = await this._ensureDb();
     let result: TResult;
     await this.client.withSession(async (session) => {
       return session.withTransaction(async (session) => {
         result = await handler(session, db);
-      });
+      }, options);
     });
     // @ts-expect-error The `await` ensures `result` has a value.
     return result;

--- a/src/Database/Database.ts
+++ b/src/Database/Database.ts
@@ -2,12 +2,12 @@ import { ClientSession, Db, TransactionOptions } from 'mongodb';
 
 import { LoggerContract } from '@ioc:Adonis/Core/Logger';
 import type {
+  ConnectionContract,
   ConnectionManagerContract,
   DatabaseContract,
   MongodbConfig,
 } from '@ioc:Zakodium/Mongodb/Database';
 
-import { Connection } from './Connection';
 import { ConnectionManager } from './ConnectionManager';
 
 export class Database implements DatabaseContract {
@@ -43,8 +43,10 @@ export class Database implements DatabaseContract {
     }
   }
 
-  public connection(connectionName = this.primaryConnectionName): Connection {
-    return this.manager.get(connectionName).connection as Connection;
+  public connection(
+    connectionName = this.primaryConnectionName,
+  ): ConnectionContract {
+    return this.manager.get(connectionName).connection;
   }
 
   public transaction<TResult>(

--- a/src/Database/Database.ts
+++ b/src/Database/Database.ts
@@ -1,11 +1,13 @@
+import { ClientSession, Db, TransactionOptions } from 'mongodb';
+
 import { LoggerContract } from '@ioc:Adonis/Core/Logger';
 import type {
-  ConnectionContract,
   ConnectionManagerContract,
   DatabaseContract,
   MongodbConfig,
 } from '@ioc:Zakodium/Mongodb/Database';
 
+import { Connection } from './Connection';
 import { ConnectionManager } from './ConnectionManager';
 
 export class Database implements DatabaseContract {
@@ -41,9 +43,15 @@ export class Database implements DatabaseContract {
     }
   }
 
-  public connection(
-    connectionName = this.primaryConnectionName,
-  ): ConnectionContract {
-    return this.manager.get(connectionName).connection;
+  public connection(connectionName = this.primaryConnectionName): Connection {
+    return this.manager.get(connectionName).connection as Connection;
+  }
+
+  public transaction<TResult>(
+    handler: (client: ClientSession, db: Db) => Promise<TResult>,
+    options?: TransactionOptions,
+  ): Promise<TResult> {
+    const client = this.connection();
+    return client.transaction(handler, options);
   }
 }

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -698,29 +698,6 @@ export class BaseModel {
     return this.$options.session;
   }
 
-  /**
-   * Assign client to model options for transactions use.
-   * Will throw an error if model instance already linked to a session
-   *
-   * It allows to use model init outside a transaction, but save it within a transaction.
-   *
-   * @param client
-   *
-   * @example
-   * ```ts
-   * const label = await Label.findOrFail(1);
-   * // edit some label props
-   *
-   * Database.transaction((client) => {
-   *  const documents = await Document.query({ labels: label._id }, { client }).all()
-   *  // remove label from documents when new label definition is incompatible
-   *  // call .save() for each changed documents (aware of transaction because is from query with client option)
-   *
-   *  label.useTransaction(client);
-   *  label.save();
-   * })
-   * ```
-   */
   public useTransaction(client: ClientSession): this {
     if (this.$trx) {
       const model = this.constructor.name;

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -550,7 +550,7 @@ export class BaseModel {
       $isDeleted: this.$isDeleted,
       $dirty: this.$dirty,
       $isDirty: this.$isDirty,
-      $isTransaction: Boolean(this.$trx),
+      $isTransaction: this.$isTransaction,
     };
   }
 
@@ -698,8 +698,12 @@ export class BaseModel {
     return this.$options.session;
   }
 
+  public get $isTransaction(): boolean {
+    return Boolean(this.$trx);
+  }
+
   public useTransaction(client: ClientSession): this {
-    if (this.$trx) {
+    if (this.$isTransaction) {
       const model = this.constructor.name;
       const id = String(this.id);
       const message = this.$isNew

--- a/src/Model/__tests__/Model.test.ts
+++ b/src/Model/__tests__/Model.test.ts
@@ -440,7 +440,7 @@ test('spreading a model should throw', async () => {
 });
 
 test('custom inspect function', async () => {
-  const post = await Post.query().firstOrFail();
+  const post = await Post.query().sort({ id: 1 }).firstOrFail();
   post.content = 'new content';
 
   // Delete dates to have a reproducible snapshot.

--- a/src/Model/__tests__/__snapshots__/Model.test.ts.snap
+++ b/src/Model/__tests__/__snapshots__/Model.test.ts.snap
@@ -3,13 +3,14 @@
 exports[`custom inspect function 1`] = `
 "{
   Model: 'Post',
-  '$original': { _id: 4, title: 'post title 4', content: 'post content' },
-  '$attributes': { _id: 4, title: 'post title 4', content: 'new content' },
+  '$original': { _id: 1, title: 'post title 1', content: 'post content' },
+  '$attributes': { _id: 1, title: 'post title 1', content: 'new content' },
   '$isPersisted': true,
   '$isNew': false,
   '$isLocal': false,
   '$isDeleted': false,
   '$dirty': { content: 'new content' },
-  '$isDirty': true
+  '$isDirty': true,
+  '$isTransaction': false
 }"
 `;


### PR DESCRIPTION
+ add `transaction` shortcut on Database
+ add support for transaction options on Connection

---

As view on discord, I purpose the useTransaction on model like Lucid API. And I add the transaction shortcut on Database.
transaction API on connection support options.

I will need to add some test cases also maybe (around transaction)