### PR TITLE
fix: add missing triple-slash reference for transaction types

### DIFF
--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -6,3 +6,4 @@
 /// <reference path="./migration.ts" preserve="true" />
 /// <reference path="./objectid.ts" preserve="true" />
 /// <reference path="./odm.ts" preserve="true" />
+/// <reference path="./transaction.ts" preserve="true" />


### PR DESCRIPTION
I wonder how it was working before